### PR TITLE
Update .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -58,7 +58,7 @@
     "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
     "no-with": 2,
     "radix": 2,
-    "vars-on-top": 2,
+    "vars-on-top": 0,
     "wrap-iife": [2, "outside"],
     "yoda": 2
   },


### PR DESCRIPTION
Отключено правило vars-on-top, чтобы объявлять переменные не только в начале функции, но и ниже.
Например, при описании циклов:
for(var i=0; i>10; i++)